### PR TITLE
Remove Caching For Authenticator Calls

### DIFF
--- a/addon/authenticators/rails.js
+++ b/addon/authenticators/rails.js
@@ -4,13 +4,15 @@ import unchartedAjax from 'uncharted-ajax';
 var Authenticator = Devise.extend({
   restore: function(/* properties */) {
     return unchartedAjax({
-      url: '/session/me'
+      url: '/session/me',
+      cache: false
     });
   },
 
   invalidate: function() {
     return unchartedAjax({
-      url: '/users/sign_out'
+      url: '/users/sign_out',
+      cache: false
     });
   }
 });


### PR DESCRIPTION
Without explicitly preventing caching, Firefox can get stuck in an infinite login loop. 

Reproduction steps (couldn't get this to happen when running code locally, had to debug in a production environment):

1. Navigate to the application. `session/me` call returns unauthorized, redirects to login.
2. Enter valid credentials.
3. Get redirected back to login.

By setting breakpoints in Authenticator's `restore` method, you can verify that no actual requests are being sent to the server. Instead, we are getting the cached copy that we got the first time we navigate to the page.

To break the loop without the fix:

1. Open a new browser tab and manually navigate to `/session/me`.
2. Reload the original application
3. Verify that you are redirect into the application.